### PR TITLE
grab the email from the users table since there will be no entry for a d...

### DIFF
--- a/netkes/account_mgr/user_source/group_manager.py
+++ b/netkes/account_mgr/user_source/group_manager.py
@@ -34,7 +34,7 @@ WHERE u.enabled IS FALSE;
 
 _USERS_TO_DISABLE_QUERY = '''
 SELECT
-u.uniqueid, u.avatar_id, l.email
+u.uniqueid, u.avatar_id, u.email
 FROM users u
 LEFT OUTER JOIN ldap_users l ON u.uniqueid = l.uniqueid
 WHERE l.uniqueid IS NULL AND u.enabled IS TRUE;


### PR DESCRIPTION
...eleted user. This broke when we switched to the accounts api. The accounts api needs the email and disabled users won't have an entry in ldap_users.
