### PR TITLE
Replace pageit in users with django Paginator backed implementation

### DIFF
--- a/django/apps/blue_management/blue_mgnt/templates/index.html
+++ b/django/apps/blue_management/blue_mgnt/templates/index.html
@@ -130,9 +130,34 @@
             {% endfor %}
 	</tbody>
 </table>
-{% if page >= 1 %}
-{% block pagination %}{% include "partials/pagination-widget.html" %}{% endblock pagination %}
+{% block pagination %}
+<div class="widget-pagination">
+{% if pagination.num_pages > 1 %}
+	<ul>
+		{% if pagination.paginator_page.has_previous %}
+			<li><a href="{% url 'blue_mgnt:users' %}?page={{ pagination.paginator_page.previous_page_number }}">Previous</a></li>
+		{% endif %}
+
+		{% for page in pagination.page_range %}
+			{% if page %}
+				{% if page == pagination.page %}
+					<li class="active">{{ page }}</li>
+				{% else %}
+					<li><a href="{% url 'blue_mgnt:users' %}?page={{ page }}">{{ page }}</a></li>
+				{% endif %}
+			{% else %}
+				<li>...</li>
+			{% endif %}
+		{% endfor %}
+
+		{% if pagination.paginator_page.has_next %}
+			<li><a href="{% url 'blue_mgnt:users' %}?page={{ pagination.paginator_page.next_page_number }}">Next</a></li>
+		{% endif %}
+	</ul>
 {% endif %}
+</div>
+{% endblock pagination %}
+
 <div class="widget-splitactions">
 	<div class="rhs">
         <input type="hidden" value="{{ search }}" name="search">

--- a/django/apps/blue_management/blue_mgnt/views/users.py
+++ b/django/apps/blue_management/blue_mgnt/views/users.py
@@ -3,8 +3,8 @@ from base64 import b32encode
 import csv
 
 from views import enterprise_required, log_admin_action
+from views import Pagination
 from views import ReadOnlyWidget, get_base_url, SIZE_OF_GIGABYTE
-from views import pageit
 from settings import PasswordForm
 from groups import get_config_group
 
@@ -240,14 +240,13 @@ def get_login_link(username):
 
 @enterprise_required
 def users(request, api, account_info, config, username, saved=False):
-    page = int(request.GET.get('page', 1))
     show_disabled = int(request.GET.get('show_disabled', 1))
     search_back = request.GET.get('search_back', '')
     groups = api.list_groups()
     features = api.enterprise_features()
     search = request.GET.get('search', '')
     local_groups = get_local_groups(config, groups)
-    all_pages=pageit('users', api, page, None)
+    pagination = Pagination(api.get_user_count(), request.GET.get('page'))
     if not search:
         search = request.POST.get('search', '')
 
@@ -271,28 +270,21 @@ def users(request, api, account_info, config, username, saved=False):
     TmpUserForm = get_user_form(local_groups)
     TmpUserFormSet = formset_factory(TmpUserForm, extra=0, formset=BaseUserFormSet)
     DeleteUserFormSet = formset_factory(DeleteUserForm, extra=0, can_delete=True)
-    page = int(page)
-    user_limit = 25
-    user_offset = user_limit * (page - 1)
     if search_back == '1':
         search = ''
-        all_users = api.list_users(user_limit, user_offset)
+        all_users = api.list_users(pagination.per_page, pagination.query_offset)
     elif search:
-        all_users = api.search_users(search, user_limit, user_offset)
+        all_users = api.search_users(search, pagination.per_page, pagination.query_offset)
     else:
-        all_users = api.list_users(user_limit, user_offset)
-
-    next_page = len(all_users) == user_limit
-
-    all_users.sort(key=lambda x: x['creation_time'], reverse=True)
+        all_users = api.list_users(pagination.per_page, pagination.query_offset)
 
     if not show_disabled:
         all_users = [x for x in all_users if x['enabled']]
-    page_users = all_users
 
-    initial = []
-    for x in page_users:
-        entry = dict(username=x['username'],
+    all_users.sort(key=lambda x: x['creation_time'], reverse=True)
+
+    def _user_to_dict(x):
+        return dict(username=x['username'],
                      email=x['email'],
                      orig_email=x['email'],
                      user_detail=x['email'],
@@ -308,16 +300,13 @@ def users(request, api, account_info, config, username, saved=False):
                      is_local_user=is_local_user(config, x['group_id']),
                      group_name=get_group_name(groups, x['group_id']),
                     )
-        initial.append(entry)
-    local_users = []
-    for user_row in initial:
-        if user_row['is_local_user']:
-            local_users.append(user_row)
+    users = map(_user_to_dict, all_users)
+    local_users = [user for user in users if user['is_local_user']]
     for x, local_user in enumerate(local_users):
         local_user['index'] = x
 
     tmp_user_formset = TmpUserFormSet(initial=local_users, prefix='tmp_user')
-    delete_user_formset = DeleteUserFormSet(initial=initial, prefix='delete_user')
+    delete_user_formset = DeleteUserFormSet(initial=users, prefix='delete_user')
     user_csv = UserCSVForm()
     new_user = NewUserForm()
 
@@ -343,31 +332,27 @@ def users(request, api, account_info, config, username, saved=False):
                 return redirect(reverse('blue_mgnt:users_saved') + '?search=%s' % search)
 
     index = 0
-    for user in initial:
+    for user in users:
         if user['is_local_user']:
             user['form'] = tmp_user_formset[index]
             index += 1
     
     return render_to_response('index.html', dict(
-        all_users=initial,
         user=request.user,
-        page=page,
         config=config,
-        next_page=next_page,
         new_user=new_user,
         username=username,
         tmp_user_formset=tmp_user_formset,
         delete_user_formset=delete_user_formset,
         user_csv=user_csv,
         features=api.enterprise_features(),
-        page_users=page_users,
         saved=saved,
         account_info=account_info,
         show_disabled=show_disabled,
         search=search,
         search_back=search_back,
-        users_and_delete=zip(initial, delete_user_formset),
-        all_pages=all_pages,
+        users_and_delete=zip(users, delete_user_formset),
+        pagination=pagination,
     ),
     RequestContext(request))
 


### PR DESCRIPTION
pageit tried to do too many things not related to pagination (mapped method name to count function, held url name for template) and yet didn't do enough for pagination (didn't validate page numbers, didn't assist in determining which page numbers/buttons to render in pagination widget).

This PR replaces pageit in the users view (other views still continue to use pageit for now) with a new implementation built on top of django's Paginator.  