### PR TITLE
changed link to reference startup guide

### DIFF
--- a/django/apps/blue_management/blue_mgnt/templates/base.html
+++ b/django/apps/blue_management/blue_mgnt/templates/base.html
@@ -57,7 +57,7 @@
 			<ul>
                 <li>{{ account_info.info.company_name }}</li>
 				<li>{{ username }}</li>
-                <li class="line"><a target="_blank" href="https://spideroak.com/business/blue/docs/">
+                <li class="line"><a target="_blank" href="https://spideroak.com/mcuserman/">
                     <i class="ss-icon">&#x2753;</i>Help
                 </a></li>
 				<li class="line"><a href="{% url "blue_mgnt:logout" %}"><i class="ss-icon">&#x1F512;</i>Logout</a></li>


### PR DESCRIPTION
It's been requested that this link be changed to point to the startup guide on SpiderOak.com