### PR TITLE
Show / hide fields based on conditional parent value

### DIFF
--- a/django/apps/blue_management/blue_mgnt/static/js/policies.js
+++ b/django/apps/blue_management/blue_mgnt/static/js/policies.js
@@ -1,0 +1,29 @@
+(function() {
+    function editableByInheritance(event) {
+        var select = event.target;
+        console.log(event);
+        if (select.value === '--inherit--') {
+            $(select).parent().siblings('td').children()[0].disabled = true;
+        } else {
+            $(select).parent().siblings('td').children()[0].disabled = false;
+        }
+    }
+
+    function updateInheritanceSelection(event) {
+        console.log(event);
+        var input = event.target;
+        var inheritance = $(input).parent().siblings('td').children('select')[0];
+
+        if (inheritance.value === '--unset--') {
+            inheritance.value = '--set--';
+        }
+    }
+
+    $('.policy-inherit-select').each(function() {
+        editableByInheritance({'target': this});
+        $(this).change(editableByInheritance);
+
+        $($(this).parent().siblings('td').children()[0]).change(updateInheritanceSelection);
+    })
+
+})();

--- a/django/apps/blue_management/blue_mgnt/static/js/policies.js
+++ b/django/apps/blue_management/blue_mgnt/static/js/policies.js
@@ -1,29 +1,65 @@
-(function() {
+(function () {
+    "use strict";
+
+    function changeVisibiltyOnParentCondition(event) {
+        var parent = event.target;
+        var parent_name = parent.id.substring(3); // remove id_ from parent id
+
+        $("[data-parent='{}']".replace("{}", parent_name)).each(function () {
+            console.log(parent.value);
+            console.log($(this).data('conditional-parent-value'));
+
+            if ($(this).data("conditional-parent-value") === parent.value) {
+                $(this).show();
+            } else if ($(this).data("conditional-parent-value").indexOf(parent.value) > -1) {
+                // Check if parent value is in a list of accepted values
+                $(this).parent().parent().show();
+            } else if ($(this).data("conditional-parent-value") === "True" && $(parent).is(":checked")) {
+                // if conditional value is true and the checkbox is checked, show this child
+                $(this).parent().parent().show(); // this should show the table row
+            } else {
+                $(this).parent().parent().hide(); // this should hide the table row
+            }
+        });
+    }
+
+    $("[data-parent]").each(function () {
+        var parent = $("#id_" + $(this).data("parent"));
+        parent.change(changeVisibiltyOnParentCondition);
+        parent.change();
+    });
+
+
     function editableByInheritance(event) {
+        // use this function to make the field editable or read only
         var select = event.target;
-        console.log(event);
-        if (select.value === '--inherit--') {
-            $(select).parent().siblings('td').children()[0].disabled = true;
+
+        if (select.value === "--inherit--") {
+            $(select).parent().siblings("td").children()[0].disabled = true;
         } else {
-            $(select).parent().siblings('td').children()[0].disabled = false;
+            $(select).parent().siblings("td").children()[0].disabled = false;
         }
     }
 
     function updateInheritanceSelection(event) {
-        console.log(event);
+        // Changes --unset-- inheritance to --set-- when the field value is updated
         var input = event.target;
-        var inheritance = $(input).parent().siblings('td').children('select')[0];
+        var inheritance = $(input).parent().siblings("td").children("select")[0];
 
-        if (inheritance.value === '--unset--') {
-            inheritance.value = '--set--';
+        if (inheritance.value === "--unset--") {
+            inheritance.value = "--set--";
         }
     }
 
-    $('.policy-inherit-select').each(function() {
-        editableByInheritance({'target': this});
+    $(".policy-inherit-select").each(function () {
+        /* bind functions to thier events and run editableByInheritance
+        when the page loads */
         $(this).change(editableByInheritance);
+        // Trigger the change event
+        $(this).change();
 
-        $($(this).parent().siblings('td').children()[0]).change(updateInheritanceSelection);
-    })
+        $($(this).parent().siblings("td").children()[0]).change(updateInheritanceSelection);
+
+    });
 
 })();

--- a/django/apps/blue_management/blue_mgnt/templates/policy_detail.html
+++ b/django/apps/blue_management/blue_mgnt/templates/policy_detail.html
@@ -17,3 +17,7 @@
 {% include 'partials/policy_form.html' %}
 
 {% endblock content %}
+
+{% block js_main %}
+<script src="/static/blue_mgnt/js/policies.js" type="text/javascript"></script>
+{% endblock %}

--- a/django/apps/blue_management/blue_mgnt/templates/policy_list.html
+++ b/django/apps/blue_management/blue_mgnt/templates/policy_list.html
@@ -9,7 +9,11 @@
 {% block content %}
 <h1 class="page-header">
     <i class="ss-icon">&#xEE00;</i> Policies
+    <div class="actions">
+        <a href="{% url 'blue_mgnt:policy_create' %}" class='button button-primary-basic'>Add Policy</a>
+    </div>
 </h1>
+
 <table class="widget-table">
   <thead>
     <th>Name</th>


### PR DESCRIPTION
This PR does the following:

* When copying a policy, the original policy's values show in readonly fields with a setting of Inherit
* Child fields are only show if the conditional parent value is correct
* Fields are sorted better (parents appear above children, regardless of alphabetical order)
* Add Policy button added to policy list
* Bug fixes, specifically when validating fields